### PR TITLE
fix: was not passing all arguments through from batch script to powershell script

### DIFF
--- a/update_xml.bat
+++ b/update_xml.bat
@@ -6,7 +6,7 @@ echo Running update script...
 if "%~1"=="" (
     powershell -ExecutionPolicy Bypass -File "%~dp0update_xml.ps1"
 ) else (
-    powershell -ExecutionPolicy Bypass -File "%~dp0update_xml.ps1" -XmlFilePath "%~1"
+    powershell -ExecutionPolicy Bypass -File "%~dp0update_xml.ps1" %*
 )
 
 echo.


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed argument passing from batch to PowerShell script

- Replaced hardcoded parameter with wildcard argument forwarding


___

### **Changes diagram**

```mermaid
flowchart LR
  batch["update_xml.bat"] -- "passes %* (all args)" --> powershell["update_xml.ps1"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update_xml.bat</strong><dd><code>Fix argument forwarding to PowerShell</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

update_xml.bat

<li>Replaced hardcoded <code>-XmlFilePath "%~1"</code> parameter with <code>%*</code> wildcard<br> <li> Now forwards all command-line arguments to PowerShell script


</details>


  </td>
  <td><a href="https://github.com/SpottyMatt/pscs6-xml-tool/pull/1/files#diff-6b50f62f631ccafe1d79e3c822d66faaba4e523e68330ee877cfadfd50667df7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>